### PR TITLE
Fix GitHub Pages deployment to serve from docs directory

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload docs directory for GitHub Pages
+          path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The workflow was uploading the entire repository root, causing URL mismatches for lecture slides. Deploy only the docs/ directory to match the expected URL structure.