### PR TITLE
Fix GitHub Pages deployment to serve from docs directory

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          # Upload docs directory for GitHub Pages
+          path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
Changed the upload path from '.' (entire repo) to 'docs' so that lecture slide links like /Lecture01/Lecture01.html resolve correctly.